### PR TITLE
Use absolute paths in browser to avoid bundling a bunch of node polyfills

### DIFF
--- a/src/collectDependencyData.js
+++ b/src/collectDependencyData.js
@@ -58,7 +58,7 @@ const getSources = (stacks, ignore) => {
         .map(line => line.match(/\((.*?)\)/))
         .filter(match => match && match[1])
         .map(match => ((match: any): Array<string>)[1])
-        .map(to => path.relative(process.cwd(), to))
+        .map(to => __NODE__ ? path.relative(process.cwd(), to) : to)
         .shift(),
     };
   });


### PR DESCRIPTION
avoid calling `path.relative(process.cwd(), to)` in browser and treeshake out polyfills for node builtins